### PR TITLE
LIBIIIF-148. Implemented retries and exception handling for HTTP requests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+backoff==2.2.1
 certifi==2022.12.7
 charset-normalizer==3.0.1
 codetiming==1.4.0

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name='image-fetcher',
     version='1.0.0rc1',
     install_requires=[
+        'backoff',
         'click',
         'codetiming',
         'requests',

--- a/tests/test_fetch_iiif_from_repo_uri.py
+++ b/tests/test_fetch_iiif_from_repo_uri.py
@@ -1,10 +1,10 @@
 import logging
+from unittest.mock import patch
 
 import pytest
-import requests
+from requests import RequestException
 
-import fetcher
-from fetcher import fetch_iiif_from_repo_uri
+from fetcher import fetch_iiif_from_repo_uri, get_url
 from iiif import ImageServer
 
 
@@ -24,30 +24,53 @@ class MockFailureResponse:
     reason = 'Not Found'
 
 
+@patch('fetcher.REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
 def test_repo_uri_outside_repo(monkeypatch, image_server):
-    monkeypatch.setattr(fetcher, 'REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match='must start with the endpoint URI'):
         fetch_iiif_from_repo_uri(image_server, 'http://other.example.com/foo')
 
 
+@patch('fetcher.REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
 def test_repo_path_no_leading_slash(monkeypatch, image_server):
-    monkeypatch.setattr(fetcher, 'REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match='must start with "/"'):
         fetch_iiif_from_repo_uri(image_server, 'http://example.com/fcrepo/rest?foo')
 
 
+@patch('requests.get', return_value=MockSuccessResponse)
+@patch('fetcher.REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
 def test_successful_retrieval(monkeypatch, image_server, caplog):
     caplog.set_level(logging.INFO)
-    monkeypatch.setattr(fetcher, 'REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
-    monkeypatch.setattr(requests, 'get', lambda *args, **kwargs: MockSuccessResponse())
     fetch_iiif_from_repo_uri(image_server, 'http://example.com/fcrepo/rest/foo')
     assert 'Fetched 1024 bytes' in caplog.text
 
 
+@patch('requests.get', return_value=MockFailureResponse)
+@patch('fetcher.REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
 def test_failed_retrieval(monkeypatch, image_server, caplog):
     caplog.set_level(logging.INFO)
-    monkeypatch.setattr(fetcher, 'REPO_ENDPOINT_URI', 'http://example.com/fcrepo/rest')
-    monkeypatch.setattr(requests, 'get', lambda *args, **kwargs: MockFailureResponse())
     with pytest.raises(RuntimeError) as e:
         fetch_iiif_from_repo_uri(image_server, 'http://example.com/fcrepo/rest/foo')
         assert 'Unable to retrieve' in str(e)
+
+
+@patch('requests.get', side_effect=RequestException)
+def test_get_url_failure(mock_get):
+    with pytest.raises(RequestException):
+        get_url('http://example.com')
+    mock_get.assert_called()
+    assert mock_get.call_count == 3
+
+
+@patch('requests.get', side_effect=[RequestException, MockSuccessResponse])
+def test_get_url_succeed_within_retries(mock_get):
+    response = get_url('http://example.com')
+    mock_get.assert_called()
+    assert mock_get.call_count == 2
+    assert response.ok
+
+
+@patch('requests.get', return_value=MockSuccessResponse)
+def test_get_url_success(mock_get):
+    response = get_url('http://example.com')
+    mock_get.assert_called_once()
+    assert response.ok


### PR DESCRIPTION
Using the backoff package to retry requests.get() call for up to three times, with exponential backoff.

https://issues.umd.edu/browse/LIBIIIF-148